### PR TITLE
Fix: 리다이렉션이 정상적으로 처리되지 않는 현상 수정

### DIFF
--- a/srcs/check_redir.c
+++ b/srcs/check_redir.c
@@ -4,7 +4,7 @@ int	check_redir_after(char **token_arr, int index)
 {
 	int	check;
 
-	check = -1;
+	check = 0;
 	if (token_arr[index] == 0)
 		return (print_error_message_syntax("newline"));
 	if (is_include_str(token_arr[index], "|", ft_strlen(token_arr[index])) == 0)

--- a/srcs/parsing.c
+++ b/srcs/parsing.c
@@ -69,6 +69,6 @@ t_cmds	*set_cmds(t_info *info, char *line)
 void	set_info(t_info *info, char *line)
 {
 	info->cmds = 0;
-	if (line != 0)
+	if (*line != 0)
 		info->cmds = set_cmds(info, line);
 }


### PR DESCRIPTION
1. check_redir 함수에서의 잘못된 반환값 수정
2. 메인 내의 line이 빈값이 들어왔을 경우 세그먼트폴트 오류 발생한 현상 수정

resolved #41