### PR TITLE
Fix: segmentation falut 에러 수정

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ SRCS_MANDATORY = srcs/setting.c \
 				 srcs/parsing.c \
 				 srcs/parsing_utils.c \
 				 srcs/parsing_utils2.c \
+				 srcs/parsing_utils3.c \
 				 srcs/ft_free.c \
 				 srcs/exec_cmd.c \
 				 srcs/exec_another.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -70,6 +70,7 @@ t_cmds	*set_cmds(t_info *info, char *line);
 char	*make_cmd_redir(char *content);
 char	*make_cmd_pipe(char *content);
 char	*make_cmd_pipe_amd_redir(char *line);
+int		check_last_pipe(char *line);
 
 char	**remove_redir(char **cmd, int start, int end);
 int		is_redir(char *c);
@@ -81,7 +82,7 @@ void	in_redir(int dst, char *infile);
 int		is_num_str(char *str);
 void	redirection(t_cmds *cmds, int backup[2]);
 
-int		exec_builtin(t_cmds *cmds, t_ev *ev, int flag);
+int		exec_builtin(t_cmds *cmds, t_ev *ev, int flag, int backup[2]);
 int		exec_another(t_cmds *cmds, char **envp, int backup[2]);
 void	exec_cmd(t_info *info);
 void	execute_cmd(char **cmd, char **envp);

--- a/srcs/exec_builtin.c
+++ b/srcs/exec_builtin.c
@@ -18,7 +18,7 @@ void	execute_builtin(char **cmd, t_ev *ev, int flag)
 		//ft_unset(cmd[1], ev);
 }
 
-int	child_builtin(t_cmds *cmds, t_ev *ev, int flag)
+int	child_builtin(t_cmds *cmds, t_ev *ev, int flag, int backup[2])
 {
 	pid_t	pid;
 
@@ -27,7 +27,7 @@ int	child_builtin(t_cmds *cmds, t_ev *ev, int flag)
 		error_excute(*(cmds->cmd), 0, "Fork function error", 1);
 	if (pid == 0)
 	{
-		redirection(cmds);
+		redirection(cmds, backup);
 		close(cmds->fd[0]);
 		dup2(cmds->fd[1], 1);
 		execute_builtin(cmds->cmd, ev, flag);
@@ -41,7 +41,7 @@ int	child_builtin(t_cmds *cmds, t_ev *ev, int flag)
 	return (0);
 }
 
-int	last_builtin(t_cmds *cmds, t_ev *ev, int flag)
+int	last_builtin(t_cmds *cmds, t_ev *ev, int flag, int backup[2])
 {
 	pid_t	pid;
 	int		status;
@@ -52,7 +52,7 @@ int	last_builtin(t_cmds *cmds, t_ev *ev, int flag)
 		error_excute(*(cmds->cmd), 0, "Fork function error", 1);
 	if (pid == 0)
 	{
-		redirection(cmds);
+		redirection(cmds, backup);
 		execute_builtin(cmds->cmd, ev, flag);
 	}
 	else if (pid > 0)
@@ -62,7 +62,7 @@ int	last_builtin(t_cmds *cmds, t_ev *ev, int flag)
 	return (get_exit_status(status));
 }
 
-int	exec_builtin(t_cmds *cmds, t_ev *ev, int flag)
+int	exec_builtin(t_cmds *cmds, t_ev *ev, int flag, int backup[2])
 {
 	int	status;
 
@@ -73,8 +73,8 @@ int	exec_builtin(t_cmds *cmds, t_ev *ev, int flag)
 		return (1);
 	}
 	if (cmds->next != 0)
-		child_builtin(cmds, ev, flag);
+		child_builtin(cmds, ev, flag, backup);
 	else
-		status = last_builtin(cmds, ev, flag);
+		status = last_builtin(cmds, ev, flag, backup);
 	return (status);
 }

--- a/srcs/exec_cmd.c
+++ b/srcs/exec_cmd.c
@@ -29,7 +29,7 @@ int	exec_controller(t_cmds *cmds, t_ev *ev, int backup[2])
 
 	flag = check_builtin(cmds->cmd);
 	if (flag > 0)
-		status = exec_builtin(cmds, ev, flag);
+		status = exec_builtin(cmds, ev, flag, backup);
 	else
 		status = exec_another(cmds, ev->evp, backup);
 	return (status);

--- a/srcs/parsing_utils.c
+++ b/srcs/parsing_utils.c
@@ -97,9 +97,21 @@ char	*make_cmd_pipe_amd_redir(char *line)
 {
 	char	*temp;
 	char	*new;
+	char	*add;
 
 	temp = make_cmd_redir(line);
 	new = make_cmd_pipe(temp);
 	ft_free((void **)&temp);
+	while (check_last_pipe(new))
+	{
+		temp = new;
+		add = readline("> ");
+		new = ft_strjoin(temp, add);
+		ft_free((void **)&temp);
+		temp = make_cmd_redir(new);
+		ft_free((void **)&new);
+		new = make_cmd_pipe(temp);
+		ft_free((void **)&temp);
+	}
 	return (new);
 }

--- a/srcs/parsing_utils3.c
+++ b/srcs/parsing_utils3.c
@@ -1,0 +1,29 @@
+#include "../includes/minishell.h"
+
+int	get_last_index_arr(char **arr)
+{
+	int	i;
+
+	i = 0;
+	while (arr[i] != 0)
+		i++;
+	return (i - 1);
+}
+
+int	check_last_pipe(char *line)
+{
+	char	**arr;
+	int		i;
+
+	arr = ft_split(line, ' ');
+	if (arr == 0)
+		return (-1);
+	i = get_last_index_arr(arr);
+	if (ft_strncmp(arr[i], "|", ft_strlen(arr[i])) == 0)
+	{
+		ft_free_arr((char ***)&arr);
+		return (1);
+	}
+	ft_free_arr((char ***)&arr);
+	return (0);
+}

--- a/srcs/test.c
+++ b/srcs/test.c
@@ -1,12 +1,12 @@
 #include "../includes/minishell.h"
 
-int	main(int ac, char **av, char **envp)
-{
-	char	*line;
+// int	main(int ac, char **av, char **envp)
+// {
+// 	char	*line;
 
-	line = "a|a|d|v||e";
-	line = make_cmd_pipe(line);
-	printf("%s\n", line);
-	while (1)
-		;
-}
+// 	line = "a|a|d|v||e";
+// 	line = make_cmd_pipe(line);
+// 	printf("%s\n", line);
+// 	while (1)
+// 		;
+// }


### PR DESCRIPTION
1. readline으로 마지막에 파이프가 오는 경우 segmentation falut가 발생하는 현상 수정
2. 마지막에 파이프가 오는 경우 표준 입력을 통해 사용자에게 마지막 명령어를 받도록 수정

resolved #48