### PR TITLE
Fix: env 기능추가

### DIFF
--- a/srcs/builtin_cmd.c
+++ b/srcs/builtin_cmd.c
@@ -24,7 +24,8 @@ int	ft_env(t_list *envl)
 {
 	while (envl)
 	{
-		printf("%s\n", (char *)envl->content);
+		if(strchr(envl->content, '='))
+			printf("%s\n", (char *)envl->content);
 		envl = envl->next;
 	}
 	return (1);


### PR DESCRIPTION
1. 값이 없는 환경변수의 경우, env로 출력되지 않게끔 변경

resolved #67