### PR TITLE
BUG : 시그널 함수 비정상 작동 해결

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ SRCS_MANDATORY = srcs/setting.c \
 				 srcs/check_redir.c
 SRCS_BONUS = 
 
-COMFILE_FLAGS = -lreadline -L${HOME}/.brew/opt/readline/lib
-OBJ_FLAGS = -I${HOME}/.brew/opt/readline/include
-#COMFILE_FLAGS= -lreadline -L/usr/local/opt/readline/lib
-#OBJ_FLAGS=-I/usr/local/opt/readline/include
+#COMFILE_FLAGS = -lreadline -L${HOME}/.brew/opt/readline/lib
+#OBJ_FLAGS = -I${HOME}/.brew/opt/readline/include
+COMFILE_FLAGS= -lreadline -L/usr/local/opt/readline/lib
+OBJ_FLAGS=-I/usr/local/opt/readline/include
 OBJS = $(SRCS:.c=.o)
 OBJS_MANDATORY = $(SRCS_MANDATORY:.c=.o)
 OBJS_BONUS = $(SRCS_BONUS:.c=.o)

--- a/includes/setting.h
+++ b/includes/setting.h
@@ -11,7 +11,9 @@ typedef struct s_ev
 
 }	t_ev;
 
-void	handler(int sig);
+void	main_handler(int sig);
+void	sub1_handler(int sig);
+void	sub2_handler(int sig);
 void	set_terminal(void);
 void	ret_terminal(void);
 void	get_ev(t_ev *ev, char **envp);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -8,12 +8,14 @@ int	main(int ac, char **av, char **envp)
 	if (ac < 1 || av == 0 || envp == 0)
 		exit(1);
 	set_terminal();
-	signal(CTRL_C, handler);
-	signal(CTRL_SLASH, handler);
 	get_ev(&info.ev, envp);
 	while (1)
 	{
+		signal(CTRL_C, main_handler);
+		signal(CTRL_SLASH, main_handler);
 		line = readline("minishell$ ");
+		signal(CTRL_C, sub1_handler);
+		signal(CTRL_SLASH, sub1_handler);
 		if (!line)
 		{
 			printf("\033[1A");

--- a/srcs/setting.c
+++ b/srcs/setting.c
@@ -1,6 +1,25 @@
 #include "../includes/minishell.h"
 
-void	handler(int sig)
+void	sub1_handler(int sig)
+{
+	if (sig == CTRL_C)
+		printf("\n");
+	else if (sig == CTRL_SLASH)
+		printf("Quit : 3\n");
+}
+
+void	sub2_handler(int sig)
+{
+	if (sig == CTRL_C)
+		exit(130);
+	else if (sig == CTRL_SLASH)
+	{
+		printf("Quit : 3");
+		exit(131);
+	}
+}
+
+void	main_handler(int sig)
 {
 	if (sig == CTRL_C)
 	{
@@ -15,6 +34,7 @@ void	handler(int sig)
 		rl_redisplay();
 	}
 }
+
 
 void	set_terminal()
 {


### PR DESCRIPTION
1. 명령어를 받기전의 시그널 처리함수와 명령어를 받은 후의 시그널 처리함수를 분리해서 해결.

resolved #31