### PR TITLE
Fix: path 삭제 후 명령어 입력시 비정상 작동 수정

### DIFF
--- a/libft/Makefile
+++ b/libft/Makefile
@@ -10,7 +10,7 @@
 #                                                                              #
 # **************************************************************************** #
 
-CC = gcc
+CC = cc
 CFLAGS = -Wall -Werror -Wextra
 NAME = libft.a
 SRCS = ft_atoi.c \

--- a/srcs/execute_cmd.c
+++ b/srcs/execute_cmd.c
@@ -19,6 +19,7 @@ char	**find_path(char **envp, char *key)
 	int		i;
 
 	i = 0;
+	path = 0;
 	while (envp[i])
 	{
 		if (ft_strnstr(envp[i], key, ft_strlen(envp[i])))
@@ -30,6 +31,8 @@ char	**find_path(char **envp, char *key)
 		}
 		i++;
 	}
+	if (path == 0)
+		return (0);
 	arr = ft_split(path, ':');
 	if (arr == 0)
 		return (0);

--- a/srcs/parsing_utils.c
+++ b/srcs/parsing_utils.c
@@ -129,6 +129,7 @@ char	*make_cmd_pipe_amd_redir(t_info *info, char *line)
 		info->recent_exit_code[1] = -1;
 		return (0);
 	}
+	ft_free_arr(&word);
 	temp = make_cmd_redir(line);
 	new = make_cmd_pipe(temp);
 	ft_free((void **)&temp);


### PR DESCRIPTION
1. path 삭제 후 명령어 입력시 비정상 작동 수정
2. set_info 함수 memory leaks 발견 및 수정

resolved #90