### PR TITLE
Fix: syntax error 처리 이후 메모리누수 방지

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -84,6 +84,7 @@ char	*make_cmd_redir(char *content);
 char	*make_cmd_pipe(char *content);
 char	*make_cmd_pipe_amd_redir(t_info *info, char *line);
 int		check_last_pipe(char *line);
+char	*add_last_cmd(char *str, t_info *info);
 
 char	**remove_redir(char **cmd, int start, int end);
 int		is_redir(char *c);

--- a/srcs/check_pipe.c
+++ b/srcs/check_pipe.c
@@ -42,6 +42,8 @@ int	check_pipe_after(char **token_arr, int index)
 	int	check;
 
 	check = 0;
+	if (token_arr[index] == 0)
+		return (check);
 	if (is_include_str(token_arr[index], "|", ft_strlen(token_arr[index])) == 0)
 	{
 		if (is_include_str(token_arr[index], "||", \

--- a/srcs/parsing.c
+++ b/srcs/parsing.c
@@ -53,6 +53,7 @@ t_cmds	*set_cmds(t_info *info, char *line)
 	t_cmds	*cmd_list;
 	char	**cmds;
 	char	*new;
+	char	*temp;
 	int		i;
 
 	cmd_list = 0;
@@ -67,6 +68,14 @@ t_cmds	*set_cmds(t_info *info, char *line)
 		info->recent_exit_code = (int *)malloc(sizeof(int) * 2);
 		info->recent_exit_code[0] = 258;
 		info->recent_exit_code[1] = -1;
+		ft_free((void **)&new);
+		return (0);
+	}
+	temp = new;
+	new = add_last_cmd(temp, info);
+	if (new == 0)
+	{
+		ft_free((void **)&temp);
 		return (0);
 	}
 	cmds = ft_split(new, '|');

--- a/srcs/parsing_utils.c
+++ b/srcs/parsing_utils.c
@@ -109,7 +109,6 @@ char	*make_cmd_pipe_amd_redir(t_info *info, char *line)
 {
 	char	*temp;
 	char	*new;
-	char	*add;
 	char	**word;
 	int		i;
 
@@ -127,34 +126,12 @@ char	*make_cmd_pipe_amd_redir(t_info *info, char *line)
 		info->recent_exit_code = (int *)malloc(sizeof(int) * 2);
 		info->recent_exit_code[0] = 258;
 		info->recent_exit_code[1] = -1;
+		ft_free_arr(&word);
 		return (0);
 	}
 	ft_free_arr(&word);
 	temp = make_cmd_redir(line);
 	new = make_cmd_pipe(temp);
 	ft_free((void **)&temp);
-	while (check_last_pipe(new))
-	{
-		temp = new;
-		// 여기서 시그널 ctrl+d가 감지되면 에러처리 되도록 가능한지?
-		add = readline("> ");
-		// 임시조치
-		if (add == 0)
-		{
-			print_error_message("\rsyntax error", "unexpected end of file");
-			if (info->recent_exit_code != 0)
-				ft_free((void **)&info->recent_exit_code);
-			info->recent_exit_code = (int *)malloc(sizeof(int) * 2);
-			info->recent_exit_code[0] = 258;
-			info->recent_exit_code[1] = -1;
-			return (0);
-		}
-		new = ft_strjoin(temp, add);
-		ft_free((void **)&temp);
-		temp = make_cmd_redir(new);
-		ft_free((void **)&new);
-		new = make_cmd_pipe(temp);
-		ft_free((void **)&temp);
-	}
 	return (new);
 }

--- a/srcs/parsing_utils3.c
+++ b/srcs/parsing_utils3.c
@@ -39,3 +39,35 @@ int	check_last_pipe(char *line)
 	ft_free_arr((char ***)&arr);
 	return (0);
 }
+
+char	*add_last_cmd(char *str, t_info *info)
+{
+	char	*temp;
+	char	*new;
+	char	*add;
+
+	new = str;
+	while (check_last_pipe(new))
+	{
+		temp = new;
+		add = readline("> ");
+		if (add == 0)
+		{
+			print_error_message("\rsyntax error", "unexpected end of file");
+			if (info->recent_exit_code != 0)
+				ft_free((void **)&info->recent_exit_code);
+			info->recent_exit_code = (int *)malloc(sizeof(int) * 2);
+			info->recent_exit_code[0] = 258;
+			info->recent_exit_code[1] = -1;
+			return (0);
+		}
+		new = ft_strjoin(temp, add);
+		ft_free((void **)&add);
+		ft_free((void **)&temp);
+		temp = make_cmd_redir(new);
+		ft_free((void **)&new);
+		new = make_cmd_pipe(temp);
+		ft_free((void **)&temp);
+	}
+	return (new);
+}


### PR DESCRIPTION
1. syntax error 처리 이후 메모리누수 방지
2. last pipe case에 대한 로직 순서 변경 syntax 검사 이후 cmd를 받도록 수정

resolved #95