### PR TITLE
Fix: 데이터 파싱 기능 메모리 누수 수정

### DIFF
--- a/srcs/parsing.c
+++ b/srcs/parsing.c
@@ -83,8 +83,6 @@ t_cmds	*set_cmds(t_info *info, char *line)
 		return (0);
 	while (cmds[i] != 0)
 	{
-		if (g_signal_flag == 2)
-			break ;
 		add_cmd_back(&cmd_list, make_cmd(cmds[i], info));
 		ft_free((void **)(&(cmds[i])));
 		i++;


### PR DESCRIPTION
1. SIGINT 시그널로 명령어 종료시 파싱부분에서 메모리 누수 수정

resolved #101