### PR TITLE
Fix: 미니쉘에 빈 값 입력 시 세그먼트 폴트 현상 수정

### DIFF
--- a/srcs/parsing.c
+++ b/srcs/parsing.c
@@ -97,11 +97,25 @@ t_cmds	*set_cmds(t_info *info, char *line)
 
 void	set_info(t_info *info, char *line)
 {
-	//t_cursor cursor;
+	int	i;
+	int	length;
 
-	//get_cursor_position(&cursor.col, &cursor.row);
-	//printf("%d %d", cursor.col, cursor.row);
+	i = 0;
+	length = 0;
 	info->cmds = 0;
 	if (*line != 0)
-		info->cmds = set_cmds(info, line);
+	{
+		length = ft_strlen(line);
+		while (i < length)
+		{
+			if (line[i] != ' ')
+			{
+				info->cmds = set_cmds(info, line);
+				break ;
+			}
+			i++;
+		}
+		if (i == length)
+			info->cmds = 0;
+	}
 }


### PR DESCRIPTION
1. 미니쉘에 빈 값 입력 시 세그먼트 폴트 발생 현상 수정

resolved #110