### PR TITLE
Bug: 종료코드0을 제외한 나머지값들에서 출력오류

### DIFF
--- a/srcs/parsing/change_cmd_with_list.c
+++ b/srcs/parsing/change_cmd_with_list.c
@@ -54,7 +54,10 @@ void change_node(t_list **first_node, t_info *info)
 	evl = info->ev.evl;
 	dollar = list2dollar(first_node);
 	if (*dollar == '?')
-		*dollar = *info->recent_exit_code + '0';
+	{
+		free(dollar);
+		dollar = ft_itoa(*info->recent_exit_code);
+	}
 	else
 	{
 		while (evl)


### PR DESCRIPTION
1. 기존: exit_code에 '0'아스키값을 더함
2. 수정: exit_code를 ft_itoa로 문자열로 변환

resolved #142