### PR TITLE
Bug: echo 공백관련 오류 해결

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: sehjang <sehjang@student.42seoul.k>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/07/20 15:20:00 by sehjang           #+#    #+#              #
-#    Updated: 2022/09/25 19:58:56 by sunwchoi         ###   ########.fr        #
+#    Updated: 2022/10/04 18:33:42 by sunwchoi         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -53,10 +53,10 @@ SRCS_MANDATORY = srcs/main.c \
 				 srcs/syntax/check_redir.c
 SRCS_BONUS = 
 
-#COMFILE_FLAGS = -lreadline -L${HOME}/.brew/opt/readline/lib
-#OBJ_FLAGS = -I${HOME}/.brew/opt/readline/include
-COMFILE_FLAGS= -lreadline -L/usr/local/opt/readline/lib
-OBJ_FLAGS=-I/usr/local/opt/readline/include
+COMFILE_FLAGS = -lreadline -L${HOME}/.brew/opt/readline/lib
+OBJ_FLAGS = -I${HOME}/.brew/opt/readline/include
+#COMFILE_FLAGS= -lreadline -L/usr/local/opt/readline/lib
+#OBJ_FLAGS=-I/usr/local/opt/readline/include
 OBJS = $(SRCS:.c=.o)
 OBJS_MANDATORY = $(SRCS_MANDATORY:.c=.o)
 OBJS_BONUS = $(SRCS_BONUS:.c=.o)

--- a/includes/builtin_cmd.h
+++ b/includes/builtin_cmd.h
@@ -6,7 +6,7 @@
 /*   By: sehjang <sehjang@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/16 18:59:17 by sehjang           #+#    #+#             */
-/*   Updated: 2022/09/16 18:59:18 by sehjang          ###   ########.fr       */
+/*   Updated: 2022/10/04 18:51:06 by sunwchoi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 # define BUILTIN_CMD_H
 
 int		excute_echo(char **cmd);
-int		ft_echo(int opt, char *str);
+int		ft_echo(int opt, char **str);
 int		ft_pwd(void);
 int		ft_env(t_list *l);
 int		ft_export(char *arg, t_ev *ev);

--- a/srcs/execute/builtin/builtin_cmd.c
+++ b/srcs/execute/builtin/builtin_cmd.c
@@ -6,7 +6,7 @@
 /*   By: sehjang <sehjang@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/16 18:55:04 by sehjang           #+#    #+#             */
-/*   Updated: 2022/09/21 17:43:08 by sunwchoi         ###   ########.fr       */
+/*   Updated: 2022/10/04 19:04:06 by sunwchoi         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,19 +19,24 @@ int	excute_echo(char **cmd)
 	if (cmd[1] != 0)
 	{
 		if (!ft_memcmp(cmd[1], "-n", 3))
-			status = ft_echo(1, cmd[2]);
+			status = ft_echo(1, cmd + 2);
 		else
-			status = ft_echo(0, cmd[1]);
+			status = ft_echo(0, cmd + 1);
 	}
 	else
-		status = ft_echo(0, cmd[1]);
+		status = ft_echo(0, cmd + 1);
 	return (status);
 }
 
-int	ft_echo(int opt, char *arg)
+int	ft_echo(int opt, char **cmd)
 {
-	if (arg)
-		write(1, arg, ft_strlen(arg));
+	while (*cmd)
+	{
+		write(1, *cmd, ft_strlen(*cmd));
+		cmd++;
+		if (*cmd)
+			write(1, " ", 1);
+	}
 	if (!opt)
 		write(1, "\n", 1);
 	return (0);


### PR DESCRIPTION
1. echo 인자에 문자열 하나만 들어오는 것때문에 공백문자열을 제대로 출력하지 못함
2. 인자에 2차원배열의 주소값을 넣도록 변경

resolved #148