### PR TITLE
Fix: builtin 명령어 식별 함수 오류 수정

### DIFF
--- a/srcs/execute/exec_cmd.c
+++ b/srcs/execute/exec_cmd.c
@@ -16,19 +16,19 @@ extern int	g_signal_flag;
 
 int	check_builtin(char **cmd)
 {
-	if (ft_strncmp(*cmd, "echo", ft_strlen(*cmd)) == 0)
+	if (ft_strncmp(*cmd, "echo", ft_strlen(*cmd) + 1) == 0)
 		return (1);
-	else if (ft_strncmp(*cmd, "env", ft_strlen(*cmd)) == 0)
+	else if (ft_strncmp(*cmd, "env", ft_strlen(*cmd) + 1) == 0)
 		return (2);
-	else if (ft_strncmp(*cmd, "pwd", ft_strlen(*cmd)) == 0)
+	else if (ft_strncmp(*cmd, "pwd", ft_strlen(*cmd) + 1) == 0)
 		return (3);
-	else if (ft_strncmp(*cmd, "export", ft_strlen(*cmd)) == 0)
+	else if (ft_strncmp(*cmd, "export", ft_strlen(*cmd) + 1) == 0)
 		return (4);
-	else if (ft_strncmp(*cmd, "cd", ft_strlen(*cmd)) == 0)
+	else if (ft_strncmp(*cmd, "cd", ft_strlen(*cmd) + 1) == 0)
 		return (5);
-	else if (ft_strncmp(*cmd, "exit", ft_strlen(*cmd)) == 0)
+	else if (ft_strncmp(*cmd, "exit", ft_strlen(*cmd) + 1) == 0)
 		return (6);
-	else if (ft_strncmp(*cmd, "unset", ft_strlen(*cmd)) == 0)
+	else if (ft_strncmp(*cmd, "unset", ft_strlen(*cmd) + 1) == 0)
 		return (7);
 	return (0);
 }


### PR DESCRIPTION
1. ft_strlen 길이를 조절하여 오류 수정

resolved #174