### PR TITLE
Feat: tokenize 배열 받아 t_cmd 구조체 생성 기능 추가

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ SRCS_MANDATORY = srcs/main.c \
 				 srcs/redirection/redirection_utils2.c \
 				 srcs/syntax/check_readline.c \
 				 srcs/syntax/check_pipe.c \
-				 srcs/syntax/check_redir.c
+				 srcs/syntax/check_redir.c \
+				 srcs/tokenize/divide_arr.c
 SRCS_BONUS = 
 
 COMFILE_FLAGS = -lreadline -L${HOME}/.brew/opt/readline/lib

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -79,6 +79,8 @@ typedef struct s_builtin_info
 	int		backup[2];
 }	t_builtin_info;
 
+# include "./tokenize.h"
+
 /*
 ** ft_free.c
 */
@@ -90,7 +92,7 @@ t_cmds	*make_cmd(char *content, t_info *info);
 void	add_cmd_back(t_cmds **cmds, t_cmds *node);
 t_cmds	*make_cmds(char *new, t_info *info);
 
-int		check_syntax(t_info *info, char *line);
+int		check_syntax(t_info *info, char *line, char **str);
 void	set_info(t_info *info, char *line);
 t_cmds	*set_cmds(t_info *info, char *line);
 
@@ -141,6 +143,8 @@ int		check_redir(char **token, int i);
 int		check_readline(char *line);
 void	change_cmd(char **cmd, t_info	*info);
 char	**make_heredoc(char *content, t_cmds *cmds, t_info *info);
+int		sub_make_heredoc(t_cmds *cmds, t_info *info, int index, char ***cmd);
+int		check_sub_readline(char **token);
 
 void	get_cursor_position(int *col, int *rows);
 void	move_cursor(int col, int row);

--- a/includes/tokenize.h
+++ b/includes/tokenize.h
@@ -1,0 +1,6 @@
+#ifndef TOKENIZE_H
+# define TOKENIZE_H
+
+t_cmds	*insert_cmds(char **token, t_info *info);
+
+#endif

--- a/srcs/parsing/parsing.c
+++ b/srcs/parsing/parsing.c
@@ -12,11 +12,14 @@
 
 #include "../../includes/minishell.h"
 
-int	check_syntax(t_info *info, char *line)
+int	check_syntax(t_info *info, char *line, char **token)
 {
 	int		flag;
 
-	flag = check_readline(line);
+	if (token == 0)
+		flag = check_readline(line);
+	else
+		flag = check_sub_readline(token);
 	if (flag != 0)
 	{
 		if (flag == 1)
@@ -39,7 +42,7 @@ t_cmds	*set_cmds(t_info *info, char *line)
 	info->history_cmd = ft_strdup(line);
 	if (info->history_cmd == 0)
 		exit(1);
-	if (check_syntax(info, line))
+	if (check_syntax(info, line, 0))
 		return (0);
 	temp = make_cmd_pipe_amd_redir(line);
 	new = add_last_cmd(temp, info);
@@ -60,7 +63,17 @@ void	set_info(t_info *info, char *line)
 {
 	int	i;
 	int	length;
+	// char	**arr;
 
+	// arr = (char **)malloc(sizeof(char *) * 7);
+	// arr[0] = ft_strdup("cat");
+	// arr[1] = ft_strdup("\"ls | $USER\"");
+	// arr[2] = ft_strdup("|");
+	// arr[3] = ft_strdup("<<");
+	// arr[4] = ft_strdup("eof");
+	// arr[5] = ft_strdup("ls");
+	// arr[6] = ft_strdup("\'$USER test\'");
+	// arr[7] = 0;
 	i = 0;
 	length = 0;
 	info->cmds = 0;
@@ -72,6 +85,7 @@ void	set_info(t_info *info, char *line)
 			if (line[i] != ' ')
 			{
 				info->cmds = set_cmds(info, line);
+				// info->cmds = insert_cmds(arr, info);
 				break ;
 			}
 			i++;
@@ -79,4 +93,16 @@ void	set_info(t_info *info, char *line)
 		if (i == length)
 			info->cmds = 0;
 	}
+	// t_cmds *temp;
+	// temp = info->cmds;
+	// while (temp != 0)
+	// {
+	// 	int i = 0;
+	// 	while (temp->cmd[i] != 0)
+	// 		printf("%s ",temp->cmd[i++]);
+	// 	printf("\n");
+	// 	temp = temp->next;
+	// }
+	// printf("완");
+	// getchar();
 }

--- a/srcs/parsing/parsing_utils3.c
+++ b/srcs/parsing/parsing_utils3.c
@@ -86,7 +86,7 @@ char	*add_last_cmd(char *str, t_info *info)
 		add = readline("> ");
 		cmd_setting();
 		if (check_null_add(add, info, backup, cursor) \
-		|| check_syntax(info, add))
+		|| check_syntax(info, add, 0))
 		{
 			ft_free((void **)&add);
 			ft_free((void **)&new);

--- a/srcs/tokenize/divide_arr.c
+++ b/srcs/tokenize/divide_arr.c
@@ -1,0 +1,94 @@
+
+#include "../../includes/minishell.h"
+
+int	get_index_arr_pipe(char **token, int index)
+{
+	int	i;
+
+	i = index;
+	while (token[i] != 0)
+	{
+		if (ft_strncmp(token[i], "|", ft_strlen(token[i])) == 0)
+			break ;
+		i++;
+	}
+	return (i);
+}
+
+char	**divide_arr(char **token, int start, int index)
+{
+	char	**new_arr;
+	int		i;
+	int		j;
+
+	i = 0;
+	j = start;
+	new_arr = (char **)malloc(sizeof(char *) * (index - start + 1));
+	if (new_arr == 0)
+		return (0);
+	while (i < index - start)
+		new_arr[i++] = ft_strdup(token[j++]);
+	new_arr[i] = 0;
+	return (new_arr);
+}
+
+int	create_heredoc(char ***cmd, t_cmds *cmds, t_info *info)
+{
+	int		i;
+	int		flag;
+
+	i = -1;
+	flag = 1;
+	while ((*cmd)[++i] != 0)
+	{
+		flag = sub_make_heredoc(cmds, info, i, cmd);
+		if (flag == 1)
+			break ;
+		else if (flag == -1)
+		{
+			ft_free_arr((char ***)cmd);
+			return (1);
+		}
+	}
+	return (0);
+}
+
+t_cmds	*create_cmds(char ***cmd, t_info *info)
+{
+	t_cmds	*cmds;
+
+	cmds = (t_cmds *)malloc(sizeof(t_cmds));
+	if (cmds == 0)
+		return (0);
+	cmds->heredoc_flag = 0;
+	cmds->heredoc_filepath = 0;
+	if (create_heredoc(cmd, cmds, info))
+		return (0);
+	cmds->cmd = *cmd;
+	return (cmds);
+}
+
+t_cmds	*insert_cmds(char **token, t_info *info)
+{
+	t_cmds	*cmds;
+	int		i;
+	int		index;
+	int		size;
+	char	**new_cmd;
+
+	i = 0;
+	if (check_syntax(info, 0, token))
+		return (0);
+	cmds = 0;
+	size = 0;
+	while (token[size] != 0)
+		size++;
+	while (i < size)
+	{
+		index = get_index_arr_pipe(token, i);
+		new_cmd = divide_arr(token, i, index);
+		add_cmd_back(&cmds, create_cmds(&new_cmd, info));
+		i = index + 1;
+	}
+	return (cmds);
+}


### PR DESCRIPTION
1. tokenize 배열을 받아 파이프를 기준으로 더블 연결리스트에 담도록 기능 추가

 resolved #180