### PR TITLE
Fix: 파이프 토큰 공백 로직 수정

### DIFF
--- a/srcs/parsing/parsing_utils2.c
+++ b/srcs/parsing/parsing_utils2.c
@@ -56,6 +56,9 @@ char	*add_str_between_pipe(char *str, char *add)
 	ft_free((void **)&new);
 	new = ft_strjoin(temp, add + i);
 	ft_free((void **)&temp);
+	temp = new;
+	new = ft_strjoin(temp, " ");
+	ft_free((void **)&temp);
 	return (new);
 }
 

--- a/srcs/parsing/parsing_utils3.c
+++ b/srcs/parsing/parsing_utils3.c
@@ -69,6 +69,8 @@ int	sub_last_cmd(char **new, char **add, t_info *info)
 	}
 	if (check_syntax(info, *add, 0))
 	{
+		if (info->history_cmd != 0)
+			ft_free((void **)&info->history_cmd);
 		info->history_cmd = ft_strdup(*new);
 		ft_free((void **)add);
 		ft_free((void **)new);
@@ -102,6 +104,5 @@ char	*add_last_cmd(char *str, t_info *info)
 			return (0);
 		ft_free((void **)&add);
 	}
-	info->history_cmd = ft_strdup(new);
 	return (new);
 }

--- a/srcs/tokenize/interpret_cmd.c
+++ b/srcs/tokenize/interpret_cmd.c
@@ -47,13 +47,19 @@ char	*interpret_cmd(char *cmd, t_info *info)
 
 void	interpret_cmds(t_cmds *cmds, t_info *info)
 {
-	int	idx;
+	int		idx;
+	char	*temp;
 
 	while (cmds)
 	{
 		idx = -1;
 		while (cmds->cmd[++idx])
+		{
+			temp = cmds->cmd[idx];
 			cmds->cmd[idx] = interpret_cmd(cmds->cmd[idx], info);
+			if (temp != 0)
+				ft_free((void **)&temp);
+		}
 		cmds = cmds->next;
 	}
 }

--- a/srcs/tokenize/set_cmd.c
+++ b/srcs/tokenize/set_cmd.c
@@ -20,11 +20,15 @@ t_cmds	*new_set_cmds(t_info *info, char *line)
 	char	**temp;
 
 	cmds = 0;
+	info->history_cmd = ft_strdup(line);
 	if (check_syntax(info, line, 0))
 		return (0);
 	new_line = add_last_cmd(line, info);
 	if (new_line == 0)
 		return (0);
+	if (info->history_cmd != 0)
+		ft_free((void **)&info->history_cmd);
+	info->history_cmd = ft_strdup(new_line);
 	token = divide_line(new_line);
 	temp = token;
 	token = divide_token_garbage(temp);


### PR DESCRIPTION
1. 파이프 뒤쪽도 확인하여 공백을 추가
2. interpret 함수쪽 메모리 누수 해결

resolved #199