### PR TITLE
Fix: 명령어 여러번 입력시 쓰레기 값이 담겨지는 현상 수정

### DIFF
--- a/srcs/tokenize/interpret_cmd.c
+++ b/srcs/tokenize/interpret_cmd.c
@@ -41,6 +41,7 @@ char	*interpret_cmd(char *cmd, t_info *info)
 		cmd_cpy[i++] = *(char *)cmd_lst->content;
 		cmd_lst = cmd_lst->next;
 	}
+	cmd_cpy[i] = 0;
 	ft_lstclear(&cmd_lst_cpy, free);
 	return (cmd_cpy);
 }


### PR DESCRIPTION
1. char *형을 생성할때 끝에 null 값을 넣어 해당 현상 수정

resolved #201